### PR TITLE
Make without-demo default to empty.

### DIFF
--- a/addons/purple_screwdriver/cli/screwdriver.py
+++ b/addons/purple_screwdriver/cli/screwdriver.py
@@ -122,7 +122,7 @@ class Screwdriver(Command):
         )
         parser.add_argument(
             '--without-demo', dest='without_demo',
-            default='all',
+            default='',
             help="""disable loading demo data for modules to be installed
                 (comma-separated, use "all" for all modules)
                 By default loads demo data """


### PR DESCRIPTION
This way if you don't want demo data you just use `--without-demo=all` as an option. As it is is not possible to enable demo data for all modules.
